### PR TITLE
Create DB  Schema documentation

### DIFF
--- a/documentation/db_schema/arcade_save_files.md
+++ b/documentation/db_schema/arcade_save_files.md
@@ -1,0 +1,8 @@
+# Arcade Save File Schema - Highscore Tracking
+```
+{
+    _id: string,        // arcade-{{ gamemode }}-highscore
+    value: num,             
+    player: string      // player string holding record. Of vals (bubba, leah, friend)
+}
+```

--- a/documentation/db_schema/difficulty.md
+++ b/documentation/db_schema/difficulty.md
@@ -1,0 +1,7 @@
+# Difficulty Entry
+```
+{
+    _id: string,    //difficulty
+    value: num      //of vals (1, 2, 3)
+}
+```

--- a/documentation/db_schema/level_entry.md
+++ b/documentation/db_schema/level_entry.md
@@ -1,0 +1,65 @@
+# Level Entries will consist of the following typed attributes
+
+```
+{
+    _id: string,                        //level name *or* scene name
+    level: {
+        difficulty_multiplier: num,
+        objective: ENUM,                //TIMED, LIVES, TIMEKILLS, LIVEKILLS, TIMELIVES
+        win_cond: {
+            lives: num,
+            time: num,                  //in seconds
+            kills: {
+                grunt: num,
+                mini_boss: num,
+                boss: num
+            },
+            powerups: false *or* [
+                {
+                    name: string,
+                    enabled: boolean
+                },
+                ...
+            ],
+        }
+        aliens: {
+            grunt: {
+                spawn: boolean,
+                quantity: num,
+                score: num              //associated score per kill
+            },
+            mini_boss: {
+                spawn: boolean,
+                quantity: num,
+                score: num
+            },
+            boss: {
+                spawn: boolean,
+                quantity: num,
+                score: num
+            }
+        }   
+    },
+    assets: {
+        hud: string,
+        turret: string,
+        background: string
+    },
+    scene: {
+        type: ENUM                      //ARCADE, STORY
+        cutscene: {
+            open: string,               //Hardcoded scene names
+            close: string           
+        },
+        previous: {
+            name: string,
+            type: ENUM
+        },
+        next: {
+            name: string,
+            type: ENUM
+        },
+        report: string                  //scene name of report card to show
+    }
+}
+```


### PR DESCRIPTION
added documentation so that we can track what we expect from a n entry in the DB

First step in creating the level factory is deciding the schema to use