### PR TITLE
Create Cutscene Scene

### DIFF
--- a/client/gameobjects/help_button.js
+++ b/client/gameobjects/help_button.js
@@ -6,8 +6,9 @@ export default class HelpButton extends Phaser.GameObjects.Group {
     /**
      * a button which pauses the scene entirely and takes the user to the help menu
      * @param {Phaser.Scene} scene 
+     * @param {{execFunc: function?}?} config
      */
-    constructor(scene) {
+    constructor(scene, config) {
         super(scene);
 
         const { width, height } = scene.scale;
@@ -38,7 +39,10 @@ export default class HelpButton extends Phaser.GameObjects.Group {
         
         // Add hoverclick and normal click
         this.constants.HoverClick(scene, button, () => {
+            this.scene.sound.stopAll();
             clickSound.play();
+            
+            if (config?.execFunc) { config.execFunc(); }
             
             scene.scene.pause(scene);
             this.scene.scene.launch('helpMenu', scene);

--- a/client/gameobjects/quit_button.js
+++ b/client/gameobjects/quit_button.js
@@ -6,7 +6,7 @@ export default class QuitButton extends Phaser.GameObjects.Group {
      * Creates a quit button which returns user to 'backMenu' on click, passes
      * along data to the next scene and executes any provided execFunc
      * @param {Phaser.Scene} scene 
-     * @param {{execFunc: function, backMenu: string, data: object}} config 
+     * @param {{execFunc: function, backMenu: string, data: object, cutscene: boolean?}} config 
      */
     constructor(scene, config) {
         super(scene);
@@ -48,7 +48,12 @@ export default class QuitButton extends Phaser.GameObjects.Group {
             clickSound.play();
             
             if (config.execFunc) { config.execFunc(); }
-            scene.scene.start(config.backMenu, config.data);
+            if (config.cutscene) { // overload for cutscene quit button
+                scene.scene.resume(config.backMenu, { cutscene: true });
+            } else {
+                scene.scene.start(config.backMenu, config.data);
+            }
+
             scene.scene.stop(scene); // stop the scene its in
             return;
         });

--- a/client/main.js
+++ b/client/main.js
@@ -21,6 +21,7 @@ import LevelSelectMenu from './scenes/menus/level_select';
 import StoryReportScene from './scenes/levels/story/report';
 import HelpMenu from './scenes/menus/help';
 import AdminSettingsMenu from './scenes/menus/admin_settings';
+import TemplateCutscene from './scenes/levels/story/template_cutscene';
 
 // Game Config
 var config = {
@@ -35,7 +36,7 @@ var config = {
   },
   scene: [
     InitialLoad, StartMenu, PlayerSelectMenu, GamemodeMenu, SavefileMenu, 
-    ArcadeReportScene, ArcadeMenu, DifficultySelectMenu, TimedArcade,
+    ArcadeReportScene, ArcadeMenu, DifficultySelectMenu, TimedArcade, TemplateCutscene,
     LevelFactory, TemplateLevelScene, ArcadeReadyScene, TimedTutorialScene, WorldSelectMenu,
     StoryReadyScene, LevelSelectMenu, StoryReportScene, HelpMenu, AdminSettingsMenu
   ],

--- a/client/scenes/levels/level_factory.js
+++ b/client/scenes/levels/level_factory.js
@@ -73,48 +73,28 @@ export default class LevelFactory extends Phaser.Scene {
                 res.level["liveScore" + (this.currentPlayer)] = data.level["liveScore" + (this.currentPlayer)];
             }
 
-            // Go to cutscene first
+            // Go to template cutscene first
             if (res.scene.cutscene?.open) {
-                try {
-                    this.scene.start(
-                        res.scene.cutscene.open,
-                        {
-                            meta: {
-                                playerCount: this.playerCount,
-                                players: this.players,
-                                currentPlayer: this.currentPlayer,
-                                difficulty: this.difficulty
-                            },
-                            level: res.level,
-                            assets: res.assets,
-                            scene: res.scene,
-                            name: this.nextScene.name
-                        }
-                    )
-                    return;
-                } catch (e) {
-                    // unable to load cutscene
-                    console.log(e);
-                }
-            }
+                this.scene.pause('levelFactory', res);
 
-            this.scene.start(
-                'templateLevelScene',
-                {
-                    meta: {
-                        playerCount: this.playerCount,
-                        players: this.players,
-                        currentPlayer: this.currentPlayer,
-                        difficulty: this.difficulty,
-                        world: data.meta.world // undefined if type == ARCADE
-                    },
-                    level: res.level,
-                    levels: data.levels,
-                    assets: res.assets,
-                    scene: res.scene,
-                    name: this.nextScene.name
-                }
-            )
+                this.events.addListener('pause', () => {
+                    this.events.removeListener('pause');
+                    this.scene.setVisible(false);
+
+                    this.scene.launch('templateCutscene', {
+                        url: res.scene.cutscene.open,
+                        open: true,
+                        scene: this
+                    });
+                });
+                this.events.addListener('resume', () => {
+                    this.scene.setVisible(true);
+                    this.events.removeListener('resume');
+                    this.playLevel(data, res);
+                });
+            } else {
+                this.playLevel(data, res);
+            }
         })
     }
 
@@ -135,5 +115,29 @@ export default class LevelFactory extends Phaser.Scene {
             }
         );
         loadText.setOrigin(0.5);
+    }
+
+    /**
+     * transitions to templateLevelScene
+     * @param {object} res 
+     */
+    playLevel(data, res) {
+        this.scene.start(
+            'templateLevelScene',
+            {
+                meta: {
+                    playerCount: this.playerCount,
+                    players: this.players,
+                    currentPlayer: this.currentPlayer,
+                    difficulty: this.difficulty,
+                    world: data.meta.world // undefined if type == ARCADE
+                },
+                level: res.level,
+                levels: data.levels,
+                assets: res.assets,
+                scene: res.scene,
+                name: this.nextScene.name
+            }
+        )
     }
 }

--- a/client/scenes/levels/story/template_cutscene.js
+++ b/client/scenes/levels/story/template_cutscene.js
@@ -1,0 +1,97 @@
+import HelpButton from "../../../gameobjects/help_button";
+import QuitButton from "../../../gameobjects/quit_button";
+
+/**
+ * Responsible for loading the provided video URL stored in GCS onto the canvas
+ * and playing it with proper volume. If load times out, then skip to next scene
+ * otherwise play video and on completion, continue (after cleaning up)
+ */
+export default class TemplateCutscene extends Phaser.Scene {
+    constructor() {
+        super('templateCutscene');
+    }
+
+    /**
+     * This scene was transitioned to by either level_factory or template_level
+     * [(open) ? level_factory : template_level]. url defines the video to play.
+     * @param {{
+     *      url: string,
+     *      open: boolean,
+     *      scene: Phaser.Scene
+     * }} data 
+     */
+    init(data) {
+        this.videoURL = data.url;
+        this.nextScene = (data.open) ? "levelFactory" : "templateLevelScene";
+        this.levelData = data.scene;
+    }
+
+    /**
+     * Create a document element with src as url and attach to scene to play
+     * automatically
+     */
+    create() {
+        const { width, height } = this.scale;
+
+        const loadText = this.add.text(
+            width * 0.5, 
+            height * 0.5, 
+            'Loading...',
+            {
+                fontSize: (height * 0.11) + "px",
+                fontFamily: "impact-custom",
+                align: "center",
+            }
+        );
+        loadText.setOrigin(0.5);
+
+        this.addVideo(width, height);
+
+        this.quit = new QuitButton(this, {
+            backMenu: this.levelData, 
+            cutscene: true,
+            execFunc: () => {
+                this.video.pause();
+                this.videoElt.remove(); // kill iframe
+            }
+        });
+
+        this.help = new HelpButton(this, {
+            execFunc: () => {
+                this.video.pause();
+
+                this.videoElt.style.zIndex = "-1";
+                this.events.addListener('resume', () => {
+                    this.events.removeListener('resume');
+                    this.videoElt.style.zIndex = "10";
+                    this.video.play();
+                });
+            }
+        });
+    }
+
+    addVideo(width, height) {
+        // create video
+        this.video = document.createElement('video');
+        this.video.playsInline = true;
+        this.video.src = this.videoURL;
+        this.video.width = width;
+        this.video.height = height * 0.75;
+        this.video.autoplay = true;
+        
+        // add to dom
+        this.videoElt = document.body.appendChild(this.video);
+        this.videoElt.classList.add('cutscene');
+
+        // Listen for video end and transition back
+        this.video.addEventListener('ended', (e) => {
+            this.videoElt.remove(); // kill iframe
+
+            //Transition out of scene
+            setTimeout(() => {
+                this.scene.resume(this.levelData, { cutscene: true });
+                this.scene.stop();
+            }, 500); // wait 1 sec before transition
+        });
+    }
+}

--- a/client/scenes/levels/template_level.js
+++ b/client/scenes/levels/template_level.js
@@ -589,9 +589,31 @@ export default class TemplateLevelScene extends Phaser.Scene {
 
         if (this.levelData.scene?.cutscene?.close) {
             // play close cutscene, ends with scene start, set current player to next
+            // pause this scene to transition to templatecutscene, then that
+            // should transition back here
+            this.scene.pause('templateLevelScene', {cutscene: true});
+            this.events.addListener('pause', (e, d) => {
+                if (d.cutscene) {
+                    this.events.removeListener('pause');
+                    this.scene.setVisible(false);
+                    
+                    this.scene.launch('templateCutscene', {
+                        url: this.levelData.scene.cutscene.close,
+                        open: false,
+                        scene: this
+                    });
+                }
+            });
+            this.events.addListener('resume', (e, d) => {
+                if (d.cutscene) {
+                    this.scene.setVisible(true);
+                    this.events.removeListener('resume');
+                    this.transitionScene();
+                }
+            });
+        } else {
+            this.transitionScene();
         }
-
-        this.transitionScene();
     }
 
     /**

--- a/client/styles/main.css
+++ b/client/styles/main.css
@@ -12,6 +12,14 @@ h2 {
   color: white;
 }
 
+.cutscene {
+  position: absolute;
+  z-index: 10;
+  top: 45%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
 @font-face {
   font-family: 'impact-custom';
   src: url(https://storage.googleapis.com/alieyen-blaster/public/config/impact.ttf);


### PR DESCRIPTION
Creates template cutscene scene which loads the url provided in its init data which is fetched from the mongodb entry according to documentation (cutscene.open or cutscene.close).

This url is used to create an iframe external to the phaser canvas because dom appending with phaser wasn't working.

Adds help and quit buttons. Help pauses and returns the user to the cutscene, quit progresses the user to the next step, either to the level or to the report.

Pause and resume are utilized by cutsene to prevent passing all scene data between level factory / template level and cutscene